### PR TITLE
Update plugin deps

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: QuestManager
 main: com.SkyIsland.QuestManager.QuestManagerPlugin
 version: 1.0
-softdepend: [Fanciful, Multiverse-Core]
+softdepend: [Fanciful, Multiverse-Portals, Multiverse-Inventories]
 loadfirst: Multiverse-Core, Multiverse-Portals, Multiverse-Inventories
 permissions:
     questmanager.admin:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,8 +1,7 @@
 name: QuestManager
 main: com.SkyIsland.QuestManager.QuestManagerPlugin
 version: 1.0
-softdepend: [Fanciful, Multiverse-Portals, Multiverse-Inventories]
-loadfirst: Multiverse-Core, Multiverse-Portals, Multiverse-Inventories
+softdepend: [Multiverse-Core, Multiverse-Portals, Multiverse-Inventories]
 permissions:
     questmanager.admin:
         description: The permission to do plugin-critical things like reload


### PR DESCRIPTION
Remove loadbefore, as that way making QuestManager load before Multiverse, which it shouldn't need to. If anything, it should load afterwards.

Removed Fanciful for now, since we're not relying on the plugin.
