### PR TITLE
Change the Lootable interface to better represent something which can be looted.

### DIFF
--- a/src/main/java/com/skyisland/questmanager/PlayerManager.java
+++ b/src/main/java/com/skyisland/questmanager/PlayerManager.java
@@ -42,7 +42,6 @@ import com.skyisland.questmanager.scheduling.Tickable;
 
 /**
  * Stores a database of QuestPlayers for lookup and loading
- * @author Skyler
  *
  */
 public class PlayerManager implements Tickable {

--- a/src/main/java/com/skyisland/questmanager/QuestManagerPlugin.java
+++ b/src/main/java/com/skyisland/questmanager/QuestManagerPlugin.java
@@ -141,7 +141,6 @@ import com.skyisland.questmanager.ui.menu.message.TreeMessage;
  * Provided API and Command Line interaction between enlisted quest managers and
  * the user.
  * 
- * @author Skyler
  */
 public class QuestManagerPlugin extends JavaPlugin {
 	

--- a/src/main/java/com/skyisland/questmanager/RequirementManager.java
+++ b/src/main/java/com/skyisland/questmanager/RequirementManager.java
@@ -28,7 +28,6 @@ import org.bukkit.configuration.ConfigurationSection;
 
 /**
  * Keeps track of requirement keys and registered factories
- * @author Skyler
  *
  */
 public class RequirementManager {

--- a/src/main/java/com/skyisland/questmanager/configuration/EquipmentConfiguration.java
+++ b/src/main/java/com/skyisland/questmanager/configuration/EquipmentConfiguration.java
@@ -29,7 +29,6 @@ import org.bukkit.inventory.ItemStack;
 
 /**
  * Convenience class for storing equipment configuration.
- * @author Skyler
  *
  */
 public class EquipmentConfiguration {

--- a/src/main/java/com/skyisland/questmanager/configuration/PluginConfiguration.java
+++ b/src/main/java/com/skyisland/questmanager/configuration/PluginConfiguration.java
@@ -36,7 +36,6 @@ import com.skyisland.questmanager.player.utils.SpellWeavingInvoker;
 /**
  * Wrapper class for configuration files needed by the plugin.
  * This does not include configuration files for individual quests.
- * @author Skyler
  *
  */
 public class PluginConfiguration {

--- a/src/main/java/com/skyisland/questmanager/configuration/QuestConfiguration.java
+++ b/src/main/java/com/skyisland/questmanager/configuration/QuestConfiguration.java
@@ -41,7 +41,6 @@ import com.skyisland.questmanager.ui.menu.message.Message;
 
 /**
  * Wrapper for quest configuration
- * @author Skyler
  *
  */
 public class QuestConfiguration {

--- a/src/main/java/com/skyisland/questmanager/configuration/QuestConfigurationField.java
+++ b/src/main/java/com/skyisland/questmanager/configuration/QuestConfigurationField.java
@@ -49,7 +49,6 @@ import org.bukkit.inventory.ItemStack;
  * <li> SPELLREWARD | spellreward | <i>null</i></li>
  * <li> ENDHINT | turninhint | "Turn In"</li>
  * </ul>
- * @author Skyler
  *
  */
 public enum QuestConfigurationField {

--- a/src/main/java/com/skyisland/questmanager/configuration/SessionConflictException.java
+++ b/src/main/java/com/skyisland/questmanager/configuration/SessionConflictException.java
@@ -20,7 +20,6 @@ package com.skyisland.questmanager.configuration;
 
 /**
  * Session conflict exceptions indicate that there is a conflict with creating a new session. 
- * @author Skyler
  *
  */
 public class SessionConflictException extends Exception {

--- a/src/main/java/com/skyisland/questmanager/configuration/state/QuestState.java
+++ b/src/main/java/com/skyisland/questmanager/configuration/state/QuestState.java
@@ -31,7 +31,6 @@ import com.skyisland.questmanager.quest.history.History;
 
 /**
  * Wrapper for state info config
- * @author Skyler
  *
  */
 public class QuestState {

--- a/src/main/java/com/skyisland/questmanager/configuration/state/RequirementState.java
+++ b/src/main/java/com/skyisland/questmanager/configuration/state/RequirementState.java
@@ -30,7 +30,6 @@ import org.bukkit.configuration.ConfigurationSection;
  * <li>A time limit requirement, which needs to store how much time is left</li>
  * </ul>
  * 
- * @author Skyler
  *
  */
 public class RequirementState {

--- a/src/main/java/com/skyisland/questmanager/configuration/state/StatekeepingRequirement.java
+++ b/src/main/java/com/skyisland/questmanager/configuration/state/StatekeepingRequirement.java
@@ -22,7 +22,6 @@ import org.bukkit.configuration.InvalidConfigurationException;
 
 /**
  * Keeps state information
- * @author Skyler
  *
  */
 public interface StatekeepingRequirement {

--- a/src/main/java/com/skyisland/questmanager/configuration/utils/GUID.java
+++ b/src/main/java/com/skyisland/questmanager/configuration/utils/GUID.java
@@ -20,7 +20,6 @@ package com.skyisland.questmanager.configuration.utils;
 
 /**
  * Group unique ID's! For ID'ing partys
- * @author Skyler
  *
  */
 public class GUID {

--- a/src/main/java/com/skyisland/questmanager/configuration/utils/LocationState.java
+++ b/src/main/java/com/skyisland/questmanager/configuration/utils/LocationState.java
@@ -29,7 +29,6 @@ import org.bukkit.configuration.serialization.ConfigurationSerialization;
 
 /**
  * Convenience class for saving and loading location data from config 
- * @author Skyler
  *
  */
 public class LocationState implements ConfigurationSerializable {
@@ -75,8 +74,7 @@ public class LocationState implements ConfigurationSerializable {
 	
 	/**
 	 * Stores fields and their config keys
-	 * @author Skyler
-	 *
+		 *
 	 */
 	private enum fields {
 		X("x"),

--- a/src/main/java/com/skyisland/questmanager/configuration/utils/YamlWriter.java
+++ b/src/main/java/com/skyisland/questmanager/configuration/utils/YamlWriter.java
@@ -29,7 +29,6 @@ import org.bukkit.configuration.file.YamlConfiguration;
 
 /**
  * Utility class used to make an actual good looking YAML file with comments and crap
- * @author Skyler
  *
  */
 public class YamlWriter {

--- a/src/main/java/com/skyisland/questmanager/effects/AuraEffect.java
+++ b/src/main/java/com/skyisland/questmanager/effects/AuraEffect.java
@@ -28,7 +28,6 @@ import org.bukkit.entity.Entity;
 
 /**
  * Effect where particles are constantly created around a player, as if an aura.
- * @author Skyler
  *
  */
 public class AuraEffect extends EntityEffect implements ConstantEffect, Alarmable<Integer> {

--- a/src/main/java/com/skyisland/questmanager/effects/ChargeEffect.java
+++ b/src/main/java/com/skyisland/questmanager/effects/ChargeEffect.java
@@ -28,7 +28,6 @@ import com.skyisland.questmanager.QuestManagerPlugin;
 /**
  * Charging-like effect.
  * A circle of particles appears around the target, then moves up quickly
- * @author Skyler
  *
  */
 public class ChargeEffect extends QuestEffect implements Runnable {

--- a/src/main/java/com/skyisland/questmanager/effects/ConstantEffect.java
+++ b/src/main/java/com/skyisland/questmanager/effects/ConstantEffect.java
@@ -20,7 +20,6 @@ package com.skyisland.questmanager.effects;
 
 /**
  * This effect, when played, does not stop and repeats it's effect until told to stop.
- * @author Skyler
  *
  */
 public interface ConstantEffect {

--- a/src/main/java/com/skyisland/questmanager/effects/EntityConfirmEffect.java
+++ b/src/main/java/com/skyisland/questmanager/effects/EntityConfirmEffect.java
@@ -28,7 +28,6 @@ import org.bukkit.entity.Player;
  * Effect signaling to the player that the entity they just interacted with was correct.
  * This effect was made with the 'slay' requirement in mind, where it'll display effects when you kill
  * the right kind of enemy.
- * @author Skyler
  *
  */
 public class EntityConfirmEffect extends QuestEffect {

--- a/src/main/java/com/skyisland/questmanager/effects/QuestEffect.java
+++ b/src/main/java/com/skyisland/questmanager/effects/QuestEffect.java
@@ -23,7 +23,6 @@ import org.bukkit.entity.Entity;
 
 /**
  * An effect used by the QuestManager to signal something to the player.
- * @author Skyler
  *
  */
 public abstract class QuestEffect {

--- a/src/main/java/com/skyisland/questmanager/effects/RingEffect.java
+++ b/src/main/java/com/skyisland/questmanager/effects/RingEffect.java
@@ -28,7 +28,6 @@ import org.bukkit.entity.Entity;
 
 /**
  * Effect where particles circle the player constantly.
- * @author Skyler
  *
  */
 public class RingEffect extends EntityEffect implements ConstantEffect, Alarmable<Integer> {

--- a/src/main/java/com/skyisland/questmanager/enemy/DefaultEnemy.java
+++ b/src/main/java/com/skyisland/questmanager/enemy/DefaultEnemy.java
@@ -27,7 +27,6 @@ import org.bukkit.entity.EntityType;
 /**
  * Default enemy type for default mobs in minecraft.
  * Wrapper for QM enemies
- * @author Skyler
  *
  */
 public class DefaultEnemy extends Enemy {

--- a/src/main/java/com/skyisland/questmanager/enemy/NormalEnemy.java
+++ b/src/main/java/com/skyisland/questmanager/enemy/NormalEnemy.java
@@ -217,9 +217,12 @@ public class NormalEnemy extends Enemy implements Lootable, Listener {
 		//on death, drop loot (if we have any). otherwise, don't
 		if (loot != null && !loot.isEmpty()) {
 			event.getDrops().clear();
-			event.getDrops().add(
-					Lootable.pickLoot(loot).getItem()
-					);
+			event.getDrops().add(loot().getItem());
 		}
+	}
+
+	@Override
+	public Loot loot(){
+		return Loot.pickLoot(loot);
 	}
 }

--- a/src/main/java/com/skyisland/questmanager/enemy/NormalEnemy.java
+++ b/src/main/java/com/skyisland/questmanager/enemy/NormalEnemy.java
@@ -177,11 +177,6 @@ public class NormalEnemy extends Enemy implements Lootable, Listener {
 		
 	}
 	
-	@Override
-	public List<Loot> getLoot() {
-		return loot;
-	}
-	
 	public void addLoot(Loot loot) {
 		this.loot.add(loot);
 	}
@@ -223,6 +218,6 @@ public class NormalEnemy extends Enemy implements Lootable, Listener {
 
 	@Override
 	public Loot loot(){
-		return Loot.pickLoot(loot);
+		return Loot.getRandomLoot(loot);
 	}
 }

--- a/src/main/java/com/skyisland/questmanager/enemy/NormalEnemy.java
+++ b/src/main/java/com/skyisland/questmanager/enemy/NormalEnemy.java
@@ -216,9 +216,12 @@ public class NormalEnemy extends Enemy implements Lootable, Listener {
 		//on death, drop loot (if we have any). otherwise, don't
 		if (loot != null && !loot.isEmpty()) {
 			event.getDrops().clear();
-			event.getDrops().add(
-					Lootable.pickLoot(loot).getItem()
-					);
+			event.getDrops().add(loot().getItem());
 		}
+	}
+
+	@Override
+	public Loot loot(){
+		return Loot.pickLoot(loot);
 	}
 }

--- a/src/main/java/com/skyisland/questmanager/enemy/NormalEnemy.java
+++ b/src/main/java/com/skyisland/questmanager/enemy/NormalEnemy.java
@@ -176,11 +176,6 @@ public class NormalEnemy extends Enemy implements Lootable, Listener {
 		
 	}
 	
-	@Override
-	public List<Loot> getLoot() {
-		return loot;
-	}
-	
 	public void addLoot(Loot loot) {
 		this.loot.add(loot);
 	}
@@ -222,6 +217,6 @@ public class NormalEnemy extends Enemy implements Lootable, Listener {
 
 	@Override
 	public Loot loot(){
-		return Loot.pickLoot(loot);
+		return Loot.getRandomLoot(loot);
 	}
 }

--- a/src/main/java/com/skyisland/questmanager/enemy/NormalEnemy.java
+++ b/src/main/java/com/skyisland/questmanager/enemy/NormalEnemy.java
@@ -44,7 +44,6 @@ import com.skyisland.questmanager.loot.Lootable;
 /**
  * Enemy type with very limited, straightforward customization; namely attributes.
  * Also supports loot specification
- * @author Skyler
  *
  */
 public class NormalEnemy extends Enemy implements Lootable, Listener {

--- a/src/main/java/com/skyisland/questmanager/enemy/StandardEnemy.java
+++ b/src/main/java/com/skyisland/questmanager/enemy/StandardEnemy.java
@@ -38,7 +38,6 @@ import com.skyisland.questmanager.QuestManagerPlugin;
 
 /**
  * Enemy type with equipment customization in addition to NormalMob stuff
- * @author Skyler
  *
  */
 public class StandardEnemy extends NormalEnemy {

--- a/src/main/java/com/skyisland/questmanager/loot/Loot.java
+++ b/src/main/java/com/skyisland/questmanager/loot/Loot.java
@@ -18,8 +18,11 @@
 
 package com.skyisland.questmanager.loot;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
@@ -169,15 +172,43 @@ public class Loot implements ConfigurationSerializable {
 		return weight;
 	}
 
-	public void setWeight(double weight) {
-		this.weight = weight;
-	}
-
 	public ItemStack getItem() {
 		return item;
 	}
 
-	public void setItem(ItemStack item) {
-		this.item = item;
+	/**
+	 * Standard method of selecting a piece of loot from a list of loot items.
+	 * This method will return null if the argument list is either null or empty.
+	 * <p>
+	 * The algorithm this method follows the definition of {@link Loot}'s weight member; the chance a piece
+	 * of loot is selected is equal to
+	 * &nbsp;&nbsp;&nbsp;&nbsp;(<i>weight</i>) / (<i>Pool weight total</i>)
+	 * </p>
+	 */
+	public static Loot pickLoot(List<Loot> loot) {
+		if (loot == null || loot.isEmpty()) {
+			return null;
+		}
+
+		Random rand = new Random();
+		Collections.shuffle(loot, rand);
+
+		double max = 0;
+		for (Loot l : loot) {
+			max += l.getWeight();
+		}
+
+		double index = rand.nextDouble() * max;
+		for (Loot l : loot) {
+			index -= l.getWeight();
+			if (index <= 0) {
+				//reached piece of loot to select
+				return l;
+			}
+		}
+
+		//we reached end with a positive index. Something went wrong (probably double precious error)
+		//return end of list.
+		return loot.get(loot.size() - 1);
 	}
 }

--- a/src/main/java/com/skyisland/questmanager/loot/Loot.java
+++ b/src/main/java/com/skyisland/questmanager/loot/Loot.java
@@ -185,7 +185,7 @@ public class Loot implements ConfigurationSerializable {
 	 * &nbsp;&nbsp;&nbsp;&nbsp;(<i>weight</i>) / (<i>Pool weight total</i>)
 	 * </p>
 	 */
-	public static Loot pickLoot(List<Loot> loot) {
+	public static Loot getRandomLoot(List<Loot> loot) {
 		if (loot == null || loot.isEmpty()) {
 			return null;
 		}

--- a/src/main/java/com/skyisland/questmanager/loot/Loot.java
+++ b/src/main/java/com/skyisland/questmanager/loot/Loot.java
@@ -18,8 +18,11 @@
 
 package com.skyisland.questmanager.loot;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
@@ -168,15 +171,43 @@ public class Loot implements ConfigurationSerializable {
 		return weight;
 	}
 
-	public void setWeight(double weight) {
-		this.weight = weight;
-	}
-
 	public ItemStack getItem() {
 		return item;
 	}
 
-	public void setItem(ItemStack item) {
-		this.item = item;
+	/**
+	 * Standard method of selecting a piece of loot from a list of loot items.
+	 * This method will return null if the argument list is either null or empty.
+	 * <p>
+	 * The algorithm this method follows the definition of {@link Loot}'s weight member; the chance a piece
+	 * of loot is selected is equal to
+	 * &nbsp;&nbsp;&nbsp;&nbsp;(<i>weight</i>) / (<i>Pool weight total</i>)
+	 * </p>
+	 */
+	public static Loot pickLoot(List<Loot> loot) {
+		if (loot == null || loot.isEmpty()) {
+			return null;
+		}
+
+		Random rand = new Random();
+		Collections.shuffle(loot, rand);
+
+		double max = 0;
+		for (Loot l : loot) {
+			max += l.getWeight();
+		}
+
+		double index = rand.nextDouble() * max;
+		for (Loot l : loot) {
+			index -= l.getWeight();
+			if (index <= 0) {
+				//reached piece of loot to select
+				return l;
+			}
+		}
+
+		//we reached end with a positive index. Something went wrong (probably double precious error)
+		//return end of list.
+		return loot.get(loot.size() - 1);
 	}
 }

--- a/src/main/java/com/skyisland/questmanager/loot/Loot.java
+++ b/src/main/java/com/skyisland/questmanager/loot/Loot.java
@@ -47,7 +47,6 @@ import com.skyisland.questmanager.QuestManagerPlugin;
  * The exact probability per loot generation is given as
  * &nbsp;&nbsp;&nbsp;&nbsp;(<i>weight</i>) / (<i>Pool weight total</i>)
  * </p>
- * @author Skyler
  *
  */
 public class Loot implements ConfigurationSerializable {

--- a/src/main/java/com/skyisland/questmanager/loot/Loot.java
+++ b/src/main/java/com/skyisland/questmanager/loot/Loot.java
@@ -184,7 +184,7 @@ public class Loot implements ConfigurationSerializable {
 	 * &nbsp;&nbsp;&nbsp;&nbsp;(<i>weight</i>) / (<i>Pool weight total</i>)
 	 * </p>
 	 */
-	public static Loot pickLoot(List<Loot> loot) {
+	public static Loot getRandomLoot(List<Loot> loot) {
 		if (loot == null || loot.isEmpty()) {
 			return null;
 		}

--- a/src/main/java/com/skyisland/questmanager/loot/Lootable.java
+++ b/src/main/java/com/skyisland/questmanager/loot/Lootable.java
@@ -18,17 +18,15 @@
 
 package com.skyisland.questmanager.loot;
 
-import java.util.List;
-
 /**
- * Specifies a given object keeps a list of loot you can get from it.
+ * Specifies a given object can be looted.
  * Example application are enemies (which have loot on drop) or random chests.
- * @author Skyler
- *
  */
 public interface Lootable {
-	
-	List<Loot> getLoot();
 
+	/**
+	 * Retrieve a {@link Loot}.
+	 * @return a {@link Loot}.
+	 */
 	Loot loot();
 }

--- a/src/main/java/com/skyisland/questmanager/loot/Lootable.java
+++ b/src/main/java/com/skyisland/questmanager/loot/Lootable.java
@@ -25,7 +25,6 @@ import java.util.Random;
 /**
  * Specifies a given object keeps a list of loot you can get from it.
  * Example application are enemies (which have loot on drop) or random chests.
- * @author Skyler
  *
  */
 public interface Lootable {

--- a/src/main/java/com/skyisland/questmanager/loot/Lootable.java
+++ b/src/main/java/com/skyisland/questmanager/loot/Lootable.java
@@ -18,9 +18,7 @@
 
 package com.skyisland.questmanager.loot;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 
 /**
  * Specifies a given object keeps a list of loot you can get from it.
@@ -30,41 +28,6 @@ import java.util.Random;
 public interface Lootable {
 	
 	List<Loot> getLoot();
-	
-	/**
-	 * Standard method of selecting a piece of loot from a list of loot items.
-	 * This method will return null if the argument list is either null or empty.
-	 * <p>
-	 * The algorithm this method follows the definition of {@link Loot}'s weight member; the chance a piece
-	 * of loot is selected is equal to
-	 * &nbsp;&nbsp;&nbsp;&nbsp;(<i>weight</i>) / (<i>Pool weight total</i>)
-	 * </p>
-	 */
-	static Loot pickLoot(List<Loot> loot) {
-		if (loot == null || loot.isEmpty()) {
-			return null;
-		}
-		
-		Random rand = new Random();
-		Collections.shuffle(loot, rand);
-		
-		double max = 0;
-		for (Loot l : loot) {
-			max += l.getWeight();
-		}
-		
-		double index = rand.nextDouble() * max;
-		for (Loot l : loot) {
-			index -= l.getWeight();
-			if (index <= 0) {
-				//reached piece of loot to select
-				return l;
-			}
-		}
-		
-		//we reached end with a positive index. Something went wrong (probably double precious error)
-		//return end of list.
-		return loot.get(loot.size() - 1);
-		
-	}
+
+	Loot loot();
 }

--- a/src/main/java/com/skyisland/questmanager/loot/Lootable.java
+++ b/src/main/java/com/skyisland/questmanager/loot/Lootable.java
@@ -18,16 +18,15 @@
 
 package com.skyisland.questmanager.loot;
 
-import java.util.List;
-
 /**
- * Specifies a given object keeps a list of loot you can get from it.
+ * Specifies a given object can be looted.
  * Example application are enemies (which have loot on drop) or random chests.
- *
  */
 public interface Lootable {
-	
-	List<Loot> getLoot();
 
+	/**
+	 * Retrieve a {@link Loot}.
+	 * @return a {@link Loot}.
+	 */
 	Loot loot();
 }

--- a/src/main/java/com/skyisland/questmanager/loot/Lootable.java
+++ b/src/main/java/com/skyisland/questmanager/loot/Lootable.java
@@ -18,9 +18,7 @@
 
 package com.skyisland.questmanager.loot;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 
 /**
  * Specifies a given object keeps a list of loot you can get from it.
@@ -31,41 +29,6 @@ import java.util.Random;
 public interface Lootable {
 	
 	List<Loot> getLoot();
-	
-	/**
-	 * Standard method of selecting a piece of loot from a list of loot items.
-	 * This method will return null if the argument list is either null or empty.
-	 * <p>
-	 * The algorithm this method follows the definition of {@link Loot}'s weight member; the chance a piece
-	 * of loot is selected is equal to
-	 * &nbsp;&nbsp;&nbsp;&nbsp;(<i>weight</i>) / (<i>Pool weight total</i>)
-	 * </p>
-	 */
-	static Loot pickLoot(List<Loot> loot) {
-		if (loot == null || loot.isEmpty()) {
-			return null;
-		}
-		
-		Random rand = new Random();
-		Collections.shuffle(loot, rand);
-		
-		double max = 0;
-		for (Loot l : loot) {
-			max += l.getWeight();
-		}
-		
-		double index = rand.nextDouble() * max;
-		for (Loot l : loot) {
-			index -= l.getWeight();
-			if (index <= 0) {
-				//reached piece of loot to select
-				return l;
-			}
-		}
-		
-		//we reached end with a positive index. Something went wrong (probably double precious error)
-		//return end of list.
-		return loot.get(loot.size() - 1);
-		
-	}
+
+	Loot loot();
 }

--- a/src/main/java/com/skyisland/questmanager/loot/dynamic/DynamicLoot.java
+++ b/src/main/java/com/skyisland/questmanager/loot/dynamic/DynamicLoot.java
@@ -30,7 +30,6 @@ import org.bukkit.inventory.ItemStack;
 /**
  * Loot class which holds a dynamic item rather than a static one. In other words, specifics about the
  * item are generated fresh each time (like enchantments, name, etc)
- * @author Skyler
  *
  */
 public class DynamicLoot extends Loot {

--- a/src/main/java/com/skyisland/questmanager/magic/Imbuement.java
+++ b/src/main/java/com/skyisland/questmanager/magic/Imbuement.java
@@ -38,7 +38,6 @@ import com.skyisland.questmanager.player.skill.event.CombatEvent;
 
 /**
  * An active imbuement. Watches for events, takes action, fights crime, you name it! 
- * @author Skyler
  * @see QuestPlayer
  * @see ImbuementHandler
  */

--- a/src/main/java/com/skyisland/questmanager/magic/ImbuementHandler.java
+++ b/src/main/java/com/skyisland/questmanager/magic/ImbuementHandler.java
@@ -41,7 +41,6 @@ import com.google.common.collect.Lists;
 
 /**
  * Stores imbuements and the items they come from, and handle
- * @author Skyler
  *
  */
 public class ImbuementHandler {

--- a/src/main/java/com/skyisland/questmanager/magic/ImbuementSet.java
+++ b/src/main/java/com/skyisland/questmanager/magic/ImbuementSet.java
@@ -28,7 +28,6 @@ import org.bukkit.configuration.serialization.ConfigurationSerialization;
 
 /**
  * Holds the effects of an imbuement and their potencies together for easier use everywhere
- * @author Skyler
  *
  */
 public class ImbuementSet implements ConfigurationSerializable {

--- a/src/main/java/com/skyisland/questmanager/magic/SpellPylon.java
+++ b/src/main/java/com/skyisland/questmanager/magic/SpellPylon.java
@@ -36,7 +36,6 @@ import com.skyisland.questmanager.effects.AuraEffect;
 
 /**
  * A designated rune for a rune caster spell.
- * @author Skyler
  *
  */
 public class SpellPylon implements Alarmable<Integer> {

--- a/src/main/java/com/skyisland/questmanager/magic/spell/ChargeSpell.java
+++ b/src/main/java/com/skyisland/questmanager/magic/spell/ChargeSpell.java
@@ -44,7 +44,6 @@ import com.skyisland.questmanager.player.skill.event.MagicCastEvent.MagicType;
 
 /**
  * A spell that must charge for a while, and then releases a spell
- * @author Skyler
  *
  */
 public class ChargeSpell extends SimpleSelfSpell implements Listener {

--- a/src/main/java/com/skyisland/questmanager/magic/spell/SpellWeavingManager.java
+++ b/src/main/java/com/skyisland/questmanager/magic/spell/SpellWeavingManager.java
@@ -41,7 +41,6 @@ import com.skyisland.questmanager.QuestManagerPlugin;
  * The manager keeps records of recipes and deals with configuration of spells. 
  * </p>
  * 
- * @author Skyler
  * @see SpellWeavingSpell
  *
  */

--- a/src/main/java/com/skyisland/questmanager/magic/spell/SpellWeavingSpell.java
+++ b/src/main/java/com/skyisland/questmanager/magic/spell/SpellWeavingSpell.java
@@ -41,7 +41,6 @@ import com.skyisland.questmanager.player.skill.event.MagicCastEvent;
 
 /**
  * Holds on to both the invocation recipe and the result of a spell weaving spell
- * @author Skyler
  *
  */
 public class SpellWeavingSpell extends Spell implements ConfigurationSerializable {

--- a/src/main/java/com/skyisland/questmanager/magic/spell/effect/BlockEffect.java
+++ b/src/main/java/com/skyisland/questmanager/magic/spell/effect/BlockEffect.java
@@ -30,7 +30,6 @@ import com.skyisland.questmanager.magic.MagicUser;
 
 /**
  * Manipulates blocks. This effect replaces one type of block with another
- * @author Skyler
  *
  */
 public class BlockEffect extends SpellEffect {

--- a/src/main/java/com/skyisland/questmanager/magic/spell/effect/CastPylonEffect.java
+++ b/src/main/java/com/skyisland/questmanager/magic/spell/effect/CastPylonEffect.java
@@ -31,7 +31,6 @@ import com.skyisland.questmanager.magic.SpellPylon;
 
 /**
  * Creates in the world a pylon ties to the given player of a certain type
- * @author Skyler
  *
  */
 public class CastPylonEffect extends SpellEffect {

--- a/src/main/java/com/skyisland/questmanager/magic/spell/effect/FireEffect.java
+++ b/src/main/java/com/skyisland/questmanager/magic/spell/effect/FireEffect.java
@@ -32,7 +32,6 @@ import com.skyisland.questmanager.magic.MagicUser;
 
 /**
  * Catches entities on fire
- * @author Skyler
  *
  */
 public class FireEffect extends ImbuementEffect {

--- a/src/main/java/com/skyisland/questmanager/magic/spell/effect/ImbuementEffect.java
+++ b/src/main/java/com/skyisland/questmanager/magic/spell/effect/ImbuementEffect.java
@@ -23,7 +23,6 @@ package com.skyisland.questmanager.magic.spell.effect;
  * Compatable effects are able to be scaled up or down on a whim -- as is expected for combining
  * effects with some generic scale. These effects are expected to scale up or down based on their given
  * potency -- A value where 1 signifies a normal, 100% effective effect. 
- * @author Skyler
  *
  */
 public abstract class ImbuementEffect extends SpellEffect {

--- a/src/main/java/com/skyisland/questmanager/magic/spell/effect/SpellEffect.java
+++ b/src/main/java/com/skyisland/questmanager/magic/spell/effect/SpellEffect.java
@@ -25,7 +25,6 @@ import org.bukkit.entity.Entity;
 
 /**
  * An effect a spell might have.
- * @author Skyler
  *
  */
 public abstract class SpellEffect implements ConfigurationSerializable {

--- a/src/main/java/com/skyisland/questmanager/magic/spell/effect/StatusEffect.java
+++ b/src/main/java/com/skyisland/questmanager/magic/spell/effect/StatusEffect.java
@@ -42,7 +42,6 @@ import com.skyisland.questmanager.player.QuestPlayer;
 
 /**
  * Wrapper class for potion effects put into spells
- * @author Skyler
  *
  */
 public class StatusEffect extends ImbuementEffect {

--- a/src/main/java/com/skyisland/questmanager/magic/spell/effect/SummonTamedEffect.java
+++ b/src/main/java/com/skyisland/questmanager/magic/spell/effect/SummonTamedEffect.java
@@ -39,7 +39,6 @@ import net.md_5.bungee.api.ChatColor;
 
 /**
  * Summons a tamed creature for the caster 
- * @author Skyler
  *
  */
 public class SummonTamedEffect extends SpellEffect {

--- a/src/main/java/com/skyisland/questmanager/magic/spell/effect/SwapEffect.java
+++ b/src/main/java/com/skyisland/questmanager/magic/spell/effect/SwapEffect.java
@@ -29,7 +29,6 @@ import com.skyisland.questmanager.magic.MagicUser;
 
 /**
  * Swaps location of the caster and an entity target. Does nothing on contact with a solid. 
- * @author Skyler
  *
  */
 public class SwapEffect extends SpellEffect {

--- a/src/main/java/com/skyisland/questmanager/npc/BankNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/BankNPC.java
@@ -42,7 +42,6 @@ import com.skyisland.questmanager.ui.menu.message.BioptionMessage;
 
 /**
  * NPC which allows players access to their bank storage
- * @author Skyler
  *
  */
 public class BankNPC extends SimpleStaticBioptionNPC {

--- a/src/main/java/com/skyisland/questmanager/npc/DummyNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/DummyNPC.java
@@ -39,7 +39,6 @@ import com.skyisland.questmanager.configuration.utils.LocationState;
 
 /**
  * Basic NPC with no interactivity and no movement.
- * @author Skyler
  * config:
  * <i>name</i>: "name"
  * <i>type</i>: "EntityType.VALUE.toString"

--- a/src/main/java/com/skyisland/questmanager/npc/ForgeNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/ForgeNPC.java
@@ -44,7 +44,6 @@ import com.skyisland.questmanager.ui.menu.message.SimpleMessage;
 
 /**
  * NPC which offers to and repairs a players equipment, for a fee
- * @author Skyler
  *
  */
 public class ForgeNPC extends SimpleStaticBioptionNPC {

--- a/src/main/java/com/skyisland/questmanager/npc/InnNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/InnNPC.java
@@ -45,7 +45,6 @@ import com.skyisland.questmanager.ui.menu.message.SimpleMessage;
 /**
  * NPC that offers a safe night to players
  * Stores the amount to charge players?
- * @author Skyler
  *
  */
 public class InnNPC extends SimpleStaticBioptionNPC {

--- a/src/main/java/com/skyisland/questmanager/npc/LevelupNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/LevelupNPC.java
@@ -58,7 +58,6 @@ import com.skyisland.questmanager.ui.menu.message.Message;
  * The amount given in the level up's is also determined in the configuration, including options
  * for rate and base amounts.
  * If both the base and rate amounts for any attribute, the option to increase it will not be included.
- * @author Skyler
  *
  */
 public class LevelupNPC extends SimpleNPC {

--- a/src/main/java/com/skyisland/questmanager/npc/MuteNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/MuteNPC.java
@@ -36,7 +36,6 @@ import com.skyisland.questmanager.configuration.utils.LocationState;
 
 /**
  * Basic NPC with no interactivity.
- * @author Skyler
  * config:
  * <i>name</i>: "name"
  * <i>type</i>: "EntityType.VALUE.toString"

--- a/src/main/java/com/skyisland/questmanager/npc/QuestMonsterNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/QuestMonsterNPC.java
@@ -26,7 +26,6 @@ import org.bukkit.event.entity.EntityDamageEvent;
 
 /**
  * An NPC that is a monster for a quest.
- * @author Skyler
  *
  */
 public class QuestMonsterNPC extends NPC {

--- a/src/main/java/com/skyisland/questmanager/npc/ServiceNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/ServiceNPC.java
@@ -43,7 +43,6 @@ import com.skyisland.questmanager.ui.menu.message.BioptionMessage;
 
 /**
  * NPC which offers to and repairs a players equipment, for a fee
- * @author Skyler
  *
  */
 public class ServiceNPC extends SimpleStaticBioptionNPC {

--- a/src/main/java/com/skyisland/questmanager/npc/ShopNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/ShopNPC.java
@@ -43,7 +43,6 @@ import com.skyisland.questmanager.ui.menu.message.BioptionMessage;
 
 /**
  * NPC which offers to and repairs a players equipment, for a fee
- * @author Skyler
  *
  */
 public class ShopNPC extends SimpleStaticBioptionNPC {

--- a/src/main/java/com/skyisland/questmanager/npc/SimpleBioptionNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/SimpleBioptionNPC.java
@@ -42,7 +42,6 @@ import com.skyisland.questmanager.ui.menu.message.BioptionMessage;
  * Provides a simple two-option menu when interacted with. This NPC also supports simple response
  * menus in response to each option.
  * This NPC does <b>not</b> support performing actions based on the response.
- * @author Skyler
  *
  */
 public class SimpleBioptionNPC extends SimpleNPC {

--- a/src/main/java/com/skyisland/questmanager/npc/SimpleChatNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/SimpleChatNPC.java
@@ -44,7 +44,6 @@ import com.skyisland.questmanager.ui.menu.message.SimpleMessage;
  * NPC that offers a simple message to those that interact with it.
  * SimpleChatNPCs do <b>not</b> support menus (they don't do anything if you click chat menu
  * buttons) 
- * @author Skyler
  *
  */
 public class SimpleChatNPC extends SimpleNPC {

--- a/src/main/java/com/skyisland/questmanager/npc/SimpleNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/SimpleNPC.java
@@ -25,7 +25,6 @@ import org.bukkit.entity.Entity;
 /**
  * Describes NPCs with simple movement pattern: they occasionally attempt to
  * move back to their original spot
- * @author Skyler
  *
  */
 public abstract class SimpleNPC extends NPC {

--- a/src/main/java/com/skyisland/questmanager/npc/SimpleQuestStartNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/SimpleQuestStartNPC.java
@@ -51,7 +51,6 @@ import com.skyisland.questmanager.ui.menu.message.Message;
  * NPC that starts a quest :D
  * This simple starting version mounts atop a {@link SimpleBioptionNPC}, and has all the capability
  * and limits defined therein.
- * @author Skyler
  *
  */
 public class SimpleQuestStartNPC extends SimpleStaticBioptionNPC implements CompassTrackable {

--- a/src/main/java/com/skyisland/questmanager/npc/SimpleStaticBioptionNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/SimpleStaticBioptionNPC.java
@@ -26,7 +26,6 @@ import org.bukkit.potion.PotionEffectType;
 
 /**
  * An npc that doesn't move rather then being reset
- * @author Skyler
  *
  */
 public abstract class SimpleStaticBioptionNPC extends SimpleBioptionNPC {

--- a/src/main/java/com/skyisland/questmanager/npc/TeleportNPC.java
+++ b/src/main/java/com/skyisland/questmanager/npc/TeleportNPC.java
@@ -46,7 +46,6 @@ import com.skyisland.questmanager.ui.menu.message.SimpleMessage;
 
 /**
  * NPC which offers to take a player and move them, for a fee?
- * @author Skyler
  *
  */
 public class TeleportNPC extends SimpleStaticBioptionNPC {

--- a/src/main/java/com/skyisland/questmanager/npc/utils/BankStorageManager.java
+++ b/src/main/java/com/skyisland/questmanager/npc/utils/BankStorageManager.java
@@ -42,7 +42,6 @@ import com.skyisland.questmanager.player.QuestPlayer;
  * Specifically, stores bank inventories against IDs intended to be unique per bank
  * NPC. This is not enforced -- which allows for global-type banks or aligned banks --
  * but is supported.
- * @author Skyler
  *
  */
 public class BankStorageManager {

--- a/src/main/java/com/skyisland/questmanager/npc/utils/ServiceOffer.java
+++ b/src/main/java/com/skyisland/questmanager/npc/utils/ServiceOffer.java
@@ -26,7 +26,6 @@ import org.bukkit.inventory.ItemStack;
 
 /**
  * An offer made by a service npc to purchase something.
- * @author Skyler
  *
  */
 public class ServiceOffer extends Service {

--- a/src/main/java/com/skyisland/questmanager/player/Participant.java
+++ b/src/main/java/com/skyisland/questmanager/player/Participant.java
@@ -26,7 +26,6 @@ import org.bukkit.configuration.serialization.ConfigurationSerializable;
  * An entity involved in a quest.
  * Specifically, a participant can either be a single player or a collection of players. It's
  * up to specific implementations of quests and requirements to specify which are allowed.
- * @author Skyler
  *
  */
 public interface Participant extends ConfigurationSerializable {

--- a/src/main/java/com/skyisland/questmanager/player/Party.java
+++ b/src/main/java/com/skyisland/questmanager/player/Party.java
@@ -49,7 +49,6 @@ import com.skyisland.questmanager.fanciful.FancyMessage;
 
 /**
  * A group of players who work together on 
- * @author Skyler
  *
  */
 public class Party implements Participant, Listener {

--- a/src/main/java/com/skyisland/questmanager/player/PlayerOptions.java
+++ b/src/main/java/com/skyisland/questmanager/player/PlayerOptions.java
@@ -32,7 +32,6 @@ import com.google.common.collect.Lists;
 
 /**
  * Stores player options for easier access and modification
- * @author Skyler
  * @see QuestPlayer
  */
 public class PlayerOptions implements ConfigurationSerializable {

--- a/src/main/java/com/skyisland/questmanager/player/QuestPlayer.java
+++ b/src/main/java/com/skyisland/questmanager/player/QuestPlayer.java
@@ -121,7 +121,6 @@ import io.puharesource.mc.titlemanager.api.TitleObject;
 /**
  * Player wrapper to store questing information and make saving player quest status
  * easier
- * @author Skyler
  *
  */
 public class QuestPlayer implements Participant, Listener, MagicUser, Comparable<QuestPlayer> {

--- a/src/main/java/com/skyisland/questmanager/player/skill/LogReducedSkill.java
+++ b/src/main/java/com/skyisland/questmanager/player/skill/LogReducedSkill.java
@@ -25,7 +25,6 @@ import com.skyisland.questmanager.player.QuestPlayer;
 /**
  * Same as a log Skill, except the xp gain is further decreased. The idea is that common skills
  * that apply all over the place should level up less.
- * @author Skyler
  * @see com.skyisland.questmanager.player.skill.Skill
  * @see LogReducedSkill#perform(QuestPlayer, int, boolean)
  */

--- a/src/main/java/com/skyisland/questmanager/player/skill/LogSkill.java
+++ b/src/main/java/com/skyisland/questmanager/player/skill/LogSkill.java
@@ -25,7 +25,6 @@ import com.skyisland.questmanager.player.QuestPlayer;
 /**
  * Same as a regular Skill, except the xp gain is done on a log scale;
  * The higher level you are, the less xp you get for doing an 'at-level' skill.
- * @author Skyler
  * @see Skill
  * @see LogSkill#perform(QuestPlayer, int)
  */

--- a/src/main/java/com/skyisland/questmanager/player/skill/QualityItem.java
+++ b/src/main/java/com/skyisland/questmanager/player/skill/QualityItem.java
@@ -29,7 +29,6 @@ import com.skyisland.questmanager.QuestManagerPlugin;
 
 /**
  * Item with some sort of given quality
- * @author Skyler
  *
  */
 public class QualityItem {

--- a/src/main/java/com/skyisland/questmanager/player/skill/Skill.java
+++ b/src/main/java/com/skyisland/questmanager/player/skill/Skill.java
@@ -39,7 +39,6 @@ import com.skyisland.questmanager.player.skill.defaults.TwoHandedSkill;
  * While an implementation may override the level-up and experience-gain mechanics of a skill, prebuilt ones
  * are included in this class to allow a uniform config-specified skill experience. For more information, see
  * the {@link #perform(QuestPlayer, int, boolean)} method.
- * @author Skyler
  *
  */
 public abstract class Skill implements Comparable<Skill> {

--- a/src/main/java/com/skyisland/questmanager/player/skill/SkillManager.java
+++ b/src/main/java/com/skyisland/questmanager/player/skill/SkillManager.java
@@ -24,7 +24,6 @@ import java.util.TreeSet;
 
 /**
  * Holds registered skills, configuration for skills in general, and some basic skill types.
- * @author Skyler
  *
  */
 public class SkillManager {

--- a/src/main/java/com/skyisland/questmanager/player/skill/StagedIncreaseSkill.java
+++ b/src/main/java/com/skyisland/questmanager/player/skill/StagedIncreaseSkill.java
@@ -23,7 +23,6 @@ import com.skyisland.questmanager.player.QuestPlayer;
 /**
  * A skill that doesn't just have one way to perform it -- and therefore, requires
  * more than one way to calculate xp gains.
- * @author Skyler
  *
  */
 public interface StagedIncreaseSkill {

--- a/src/main/java/com/skyisland/questmanager/player/skill/defaults/ImbuementSkill.java
+++ b/src/main/java/com/skyisland/questmanager/player/skill/defaults/ImbuementSkill.java
@@ -38,7 +38,6 @@ import com.google.common.collect.Lists;
 
 /**
  * Dictates the difficulty and potential of spell weaving spells
- * @author Skyler
  *
  */
 public class ImbuementSkill extends LogSkill implements Listener {

--- a/src/main/java/com/skyisland/questmanager/player/skill/defaults/MagicWeaverSkill.java
+++ b/src/main/java/com/skyisland/questmanager/player/skill/defaults/MagicWeaverSkill.java
@@ -44,7 +44,6 @@ import com.google.common.collect.Lists;
 
 /**
  * Skill governing combat with a weapon in main hand, magic in offhand
- * @author Skyler
  *
  */
 public class MagicWeaverSkill extends LogSkill implements Listener {

--- a/src/main/java/com/skyisland/questmanager/player/skill/defaults/SpellWeavingSkill.java
+++ b/src/main/java/com/skyisland/questmanager/player/skill/defaults/SpellWeavingSkill.java
@@ -39,7 +39,6 @@ import com.google.common.collect.Lists;
 
 /**
  * Dictates the difficulty and potential of spell weaving spells
- * @author Skyler
  *
  */
 public class SpellWeavingSkill extends Skill implements Listener {

--- a/src/main/java/com/skyisland/questmanager/player/skill/defaults/SwordAndShieldSkill.java
+++ b/src/main/java/com/skyisland/questmanager/player/skill/defaults/SwordAndShieldSkill.java
@@ -38,7 +38,6 @@ import com.google.common.collect.Lists;
 
 /**
  * Skill governing combat with a weapon in main hand, shield in offhand
- * @author Skyler
  *
  */
 public class SwordAndShieldSkill extends Skill implements Listener {

--- a/src/main/java/com/skyisland/questmanager/player/skill/event/CombatEvent.java
+++ b/src/main/java/com/skyisland/questmanager/player/skill/event/CombatEvent.java
@@ -35,7 +35,6 @@ import com.skyisland.questmanager.player.PlayerOptions;
  * Event called when some sort of combat action is happening in a 
  * {@link PluginConfiguration#getWorlds() QuestWorld}
  * by a {@link QuestPlayer QuestPlayer}
- * @author Skyler
  *
  */
 public class CombatEvent extends Event {

--- a/src/main/java/com/skyisland/questmanager/player/skill/event/CraftEvent.java
+++ b/src/main/java/com/skyisland/questmanager/player/skill/event/CraftEvent.java
@@ -27,7 +27,6 @@ import com.skyisland.questmanager.player.skill.QualityItem;
 /**
  * Called when a {@link QuestPlayer QuestPlayer} is crafting
  * an object. Specifically, called when the player is using a non-standard crafting interface.
- * @author Skyler
  *
  */
 public class CraftEvent extends Event {

--- a/src/main/java/com/skyisland/questmanager/player/skill/event/MagicApplyEvent.java
+++ b/src/main/java/com/skyisland/questmanager/player/skill/event/MagicApplyEvent.java
@@ -26,7 +26,6 @@ import org.bukkit.event.HandlerList;
 /**
  * Thrown when a {@link QuestPlayer QuestPlayer}'s spell
  * is applying a {@link SpellEffect SpellEffect}
- * @author Skyler
  *
  */
 public class MagicApplyEvent extends Event {

--- a/src/main/java/com/skyisland/questmanager/player/skill/event/MagicCastEvent.java
+++ b/src/main/java/com/skyisland/questmanager/player/skill/event/MagicCastEvent.java
@@ -26,7 +26,6 @@ import org.bukkit.event.HandlerList;
 /**
  * Thrown when a {@link QuestPlayer QuestPlayer}
  * is casting a spell.
- * @author Skyler
  *
  */
 public class MagicCastEvent extends Event {

--- a/src/main/java/com/skyisland/questmanager/player/utils/Compass.java
+++ b/src/main/java/com/skyisland/questmanager/player/utils/Compass.java
@@ -35,7 +35,6 @@ import com.skyisland.questmanager.player.QuestPlayer;
 
 /**
  * Holds methods to interface with a quest player's compass.
- * @author Skyler
  *
  */
 public class Compass {

--- a/src/main/java/com/skyisland/questmanager/player/utils/CompassTrackable.java
+++ b/src/main/java/com/skyisland/questmanager/player/utils/CompassTrackable.java
@@ -24,7 +24,6 @@ import org.bukkit.Location;
  * A class that's compass trackable means that the quest player can seek it.
  * This at the moment should only include requirements and NPCs, as they're the only thing
  * set up be automatically tracked.
- * @author Skyler
  *
  */
 public interface CompassTrackable {

--- a/src/main/java/com/skyisland/questmanager/player/utils/QuestJournal.java
+++ b/src/main/java/com/skyisland/questmanager/player/utils/QuestJournal.java
@@ -40,7 +40,6 @@ import com.skyisland.questmanager.quest.history.HistoryEvent;
 /**
  * A quest journal keeps track of the current target quest's history
  * This class provides nice helper functions for making that happen
- * @author Skyler
  * @see QuestLog
  */
 public class QuestJournal {

--- a/src/main/java/com/skyisland/questmanager/player/utils/QuestLog.java
+++ b/src/main/java/com/skyisland/questmanager/player/utils/QuestLog.java
@@ -47,7 +47,6 @@ import com.skyisland.questmanager.player.PlayerOptions;
  * Utility class for the quest log.
  * Provides nice, simple wrapper functions for the elaborate workings of the Quest Log.
  * 4-1-16 Quest Log will also now hold Skill information
- * @author Skyler
  *
  */
 public class QuestLog {

--- a/src/main/java/com/skyisland/questmanager/player/utils/SpellWeavingInvoker.java
+++ b/src/main/java/com/skyisland/questmanager/player/utils/SpellWeavingInvoker.java
@@ -33,7 +33,6 @@ import com.skyisland.questmanager.player.QuestPlayer;
 
 /**
  * Used to trigger invocation of spell weaving spells
- * @author Skyler
  *
  */
 public class SpellWeavingInvoker implements Listener {

--- a/src/main/java/com/skyisland/questmanager/quest/Goal.java
+++ b/src/main/java/com/skyisland/questmanager/quest/Goal.java
@@ -37,7 +37,6 @@ import com.skyisland.questmanager.quest.requirements.Requirement;
 /**
  * Tracks objectives in a quest.
  * Goals have specific requirements that must be met before they are considered clear.
- * @author Skyler
  *
  */
 public class Goal {

--- a/src/main/java/com/skyisland/questmanager/quest/history/HistoryEvent.java
+++ b/src/main/java/com/skyisland/questmanager/quest/history/HistoryEvent.java
@@ -20,7 +20,6 @@ package com.skyisland.questmanager.quest.history;
 
 /**
  * Keeps track of a single event in a history.
- * @author Skyler
  *
  */
 public class HistoryEvent {

--- a/src/main/java/com/skyisland/questmanager/quest/requirements/ArriveRequirement.java
+++ b/src/main/java/com/skyisland/questmanager/quest/requirements/ArriveRequirement.java
@@ -41,7 +41,6 @@ import org.bukkit.event.player.PlayerMoveEvent;
  * Requirement that a participant must arrive at a location (or be within some radius of it)
  * This requirement <b>does not require</b> that a participant <i>stay</i> at the location.
  * It only requires that someone get there at some point.
- * @author Skyler
  * @see PositionRequirement
  */
 public class ArriveRequirement extends Requirement implements Listener, StatekeepingRequirement, CompassTrackable {

--- a/src/main/java/com/skyisland/questmanager/quest/requirements/ChestRequirement.java
+++ b/src/main/java/com/skyisland/questmanager/quest/requirements/ChestRequirement.java
@@ -40,7 +40,6 @@ import com.skyisland.questmanager.quest.requirements.factory.RequirementFactory;
 
 /**
  * Requirement that a participant must interact (right click or left click or both) a certain block.
- * @author Skyler
  *
  */
 public class ChestRequirement extends Requirement implements Listener, StatekeepingRequirement, CompassTrackable {

--- a/src/main/java/com/skyisland/questmanager/quest/requirements/CountdownRequirement.java
+++ b/src/main/java/com/skyisland/questmanager/quest/requirements/CountdownRequirement.java
@@ -35,7 +35,6 @@ import com.skyisland.questmanager.scheduling.Tickable;
 
 /**
  * Requires a certain amount of time to pass before satisfied
- * @author Skyler
  *
  */
 public class CountdownRequirement extends Requirement implements Tickable, StatekeepingRequirement {

--- a/src/main/java/com/skyisland/questmanager/quest/requirements/DeliverRequirement.java
+++ b/src/main/java/com/skyisland/questmanager/quest/requirements/DeliverRequirement.java
@@ -40,7 +40,6 @@ import org.bukkit.inventory.ItemStack;
 
 /**
  * Requirement specification that checks for an itemstack and removes it when it's there
- * @author Skyler
  *
  */
 public class DeliverRequirement extends Requirement implements Listener, StatekeepingRequirement {

--- a/src/main/java/com/skyisland/questmanager/quest/requirements/InteractRequirement.java
+++ b/src/main/java/com/skyisland/questmanager/quest/requirements/InteractRequirement.java
@@ -41,7 +41,6 @@ import com.skyisland.questmanager.player.QuestPlayer;
 
 /**
  * Requirement that a participant must interact (right click or left click or both) a certain block.
- * @author Skyler
  *
  */
 public class InteractRequirement extends Requirement implements Listener, StatekeepingRequirement, CompassTrackable {

--- a/src/main/java/com/skyisland/questmanager/quest/requirements/PositionRequirement.java
+++ b/src/main/java/com/skyisland/questmanager/quest/requirements/PositionRequirement.java
@@ -39,7 +39,6 @@ import com.skyisland.questmanager.quest.requirements.factory.RequirementFactory;
  * Unlike the {@link ArriveRequirement} this requirement is that someone be located there
  * for this to be completed. That means if they leave, the requirement will no longer
  * be satisfied!
- * @author Skyler
  * @see ArriveRequirement
  */
 public class PositionRequirement extends Requirement implements Listener, CompassTrackable {

--- a/src/main/java/com/skyisland/questmanager/quest/requirements/PossessRequirement.java
+++ b/src/main/java/com/skyisland/questmanager/quest/requirements/PossessRequirement.java
@@ -38,7 +38,6 @@ import com.skyisland.questmanager.quest.requirements.factory.RequirementFactory;
 /**
  * Requirement specification that requires the user to have some quantity of a specific item
  * This requirement can also check whether or not the name of the item matches one given to it
- * @author Skyler
  *
  */
 public class PossessRequirement extends Requirement implements Listener {

--- a/src/main/java/com/skyisland/questmanager/quest/requirements/Requirement.java
+++ b/src/main/java/com/skyisland/questmanager/quest/requirements/Requirement.java
@@ -34,7 +34,6 @@ import org.bukkit.configuration.InvalidConfigurationException;
  * </ul>
  * Requirements are <b>required</b> to perform their own event checking and are required to update
  * their containing goal when upon state change. In addition, requirements must 
- * @author Skyler
  *
  */
 public abstract class Requirement {

--- a/src/main/java/com/skyisland/questmanager/quest/requirements/SlayRequirement.java
+++ b/src/main/java/com/skyisland/questmanager/quest/requirements/SlayRequirement.java
@@ -43,7 +43,6 @@ import org.bukkit.event.entity.EntityDeathEvent;
  * This requirement also will check to make sure the name of the entities slaid matches 
  * what is provided. If no name is provided, any entity of the same entity type
  * will be considered valid.
- * @author Skyler
  * @see PositionRequirement
  */
 public class SlayRequirement extends Requirement implements Listener, StatekeepingRequirement {

--- a/src/main/java/com/skyisland/questmanager/quest/requirements/TalkRequirement.java
+++ b/src/main/java/com/skyisland/questmanager/quest/requirements/TalkRequirement.java
@@ -38,7 +38,6 @@ import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 
 /**
  * Requirement that a participant must talk to an npc.
- * @author Skyler
  *
  */
 public class TalkRequirement extends Requirement implements Listener, CompassTrackable {

--- a/src/main/java/com/skyisland/questmanager/quest/requirements/TimeRequirement.java
+++ b/src/main/java/com/skyisland/questmanager/quest/requirements/TimeRequirement.java
@@ -32,7 +32,6 @@ import com.skyisland.questmanager.scheduling.Tickable;
 /**
  * Requirement that a specific time range be current. This is not a stateful requirement, and can be used
  * to great effect with other requirements (kill 10 things at night, etc)
- * @author Skyler
  *
  */
 public class TimeRequirement extends Requirement implements Tickable {

--- a/src/main/java/com/skyisland/questmanager/quest/requirements/VanquishRequirement.java
+++ b/src/main/java/com/skyisland/questmanager/quest/requirements/VanquishRequirement.java
@@ -55,7 +55,6 @@ import com.skyisland.questmanager.configuration.utils.LocationState;
  * Requirement that a given entity must be slain.
  * This requirement purposely does not require the entity be slain by certain participants.
  * Instead it is simply required that the provided entity is defeated.
- * @author Skyler
  *
  */
 public class VanquishRequirement extends Requirement implements Listener, StatekeepingRequirement, CompassTrackable {

--- a/src/main/java/com/skyisland/questmanager/region/Region.java
+++ b/src/main/java/com/skyisland/questmanager/region/Region.java
@@ -27,7 +27,6 @@ import org.bukkit.entity.Entity;
  * Regions are defined to be the range of blocks that mobs can spawn ON TOP OF;
  * When finding safe spawning locations, a region will try to look upwards to see if it's
  * safe and travel upwards to find a suitable location.
- * @author Skyler
  * TODO: Overlapping regions are a problem, and enemies spawn ANYWHERE in the region
  * instead of near the player
  */

--- a/src/main/java/com/skyisland/questmanager/region/RegionManager.java
+++ b/src/main/java/com/skyisland/questmanager/region/RegionManager.java
@@ -42,8 +42,7 @@ public final class RegionManager implements Alarmable<EnemyAlarms> {
 	
 	/**
 	 * Holds the enemy list and the music to play for the region
-	 * @author Skyler
-	 *
+		 *
 	 */
 	private static class RegionRecord {
 		

--- a/src/main/java/com/skyisland/questmanager/scheduling/DispersedScheduler.java
+++ b/src/main/java/com/skyisland/questmanager/scheduling/DispersedScheduler.java
@@ -30,7 +30,6 @@ import com.skyisland.questmanager.QuestManagerPlugin;
  * Gathers a list of scheduled Tickable entities and goes through ticking each
  * after the others. Each registered Tickable entity causes a measured wait
  * before the next creature is ticked, causing a spread out tick chain.
- * @author Skyler
  *
  */
 public class DispersedScheduler extends Scheduler {

--- a/src/main/java/com/skyisland/questmanager/scheduling/IntervalScheduler.java
+++ b/src/main/java/com/skyisland/questmanager/scheduling/IntervalScheduler.java
@@ -27,7 +27,6 @@ import com.skyisland.questmanager.QuestManagerPlugin;
 
 /**
  * Waits a prescribed amount of time, and then ticks all registered Tickables
- * @author Skyler
  *
  */
 public class IntervalScheduler extends Scheduler {

--- a/src/main/java/com/skyisland/questmanager/scheduling/Scheduler.java
+++ b/src/main/java/com/skyisland/questmanager/scheduling/Scheduler.java
@@ -21,7 +21,6 @@ package com.skyisland.questmanager.scheduling;
 
 /**
  * Keeps track of registered entities and delivers ticks in a regular fashion
- * @author Skyler
  *
  */
 public abstract class Scheduler implements Runnable {

--- a/src/main/java/com/skyisland/questmanager/scheduling/Tickable.java
+++ b/src/main/java/com/skyisland/questmanager/scheduling/Tickable.java
@@ -24,7 +24,6 @@ package com.skyisland.questmanager.scheduling;
  * ticks.
  * <p>
  * Some easy applications of ticks are movement patterns, regular regeneration, etc
- * @author Skyler
  *
  */
 public interface Tickable {

--- a/src/main/java/com/skyisland/questmanager/ui/ChatGuiHandler.java
+++ b/src/main/java/com/skyisland/questmanager/ui/ChatGuiHandler.java
@@ -37,7 +37,6 @@ import com.skyisland.questmanager.ui.menu.RespondableMenu;
 
 /**
  * Organizes, catches, and dispatches chat click events to the responsible menus
- * @author Skyler
  *
  */
 public class ChatGuiHandler implements CommandExecutor, UITickable {
@@ -62,8 +61,7 @@ public class ChatGuiHandler implements CommandExecutor, UITickable {
 	
 	/**
 	 * Internal record class for bringing together all required information about a menu.
-	 * @author Skyler
-	 *
+		 *
 	 */
 	private static class MenuRecord {
 		

--- a/src/main/java/com/skyisland/questmanager/ui/ChatMenu.java
+++ b/src/main/java/com/skyisland/questmanager/ui/ChatMenu.java
@@ -34,7 +34,6 @@ import com.skyisland.questmanager.ui.menu.message.Message;
 
 /**
  * A menu represented in chat buttons and links
- * @author Skyler
  *
  * register it with the handler, give it a unique ID and then do specific things based on argument
  * to command received!

--- a/src/main/java/com/skyisland/questmanager/ui/InventoryGuiHandler.java
+++ b/src/main/java/com/skyisland/questmanager/ui/InventoryGuiHandler.java
@@ -31,7 +31,6 @@ import com.skyisland.questmanager.QuestManagerPlugin;
 
 /**
  * Gui handler for inventory menus
- * @author Skyler
  *
  */
 public class InventoryGuiHandler implements Listener {

--- a/src/main/java/com/skyisland/questmanager/ui/UIScheduler.java
+++ b/src/main/java/com/skyisland/questmanager/ui/UIScheduler.java
@@ -28,7 +28,6 @@ import com.skyisland.questmanager.QuestManagerPlugin;
 
 /**
  * Schedule and timing handler for UI elements
- * @author Skyler
  *
  */
 public class UIScheduler implements Runnable {

--- a/src/main/java/com/skyisland/questmanager/ui/UITickable.java
+++ b/src/main/java/com/skyisland/questmanager/ui/UITickable.java
@@ -20,7 +20,6 @@ package com.skyisland.questmanager.ui;
 
 /**
  * Able to be assigned to be scheduled to the UIScheduler
- * @author Skyler
  *
  */
 public interface UITickable {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/ChatMenuOption.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/ChatMenuOption.java
@@ -26,7 +26,6 @@ import com.skyisland.questmanager.ui.menu.message.Message;
  * An 'option' for a chat menu.
  * This includes a label for the option and a corresponding action to be executed upon selection of that
  * option.
- * @author Skyler
  *
  */
 public class ChatMenuOption {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/InventoryMenu.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/InventoryMenu.java
@@ -33,7 +33,6 @@ import com.skyisland.questmanager.ui.menu.inventory.GuiInventory;
 
 /**
  * A menu implemented as an inventory
- * @author Skyler
  *
  */
 public class InventoryMenu implements Listener {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/SimpleChatMenu.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/SimpleChatMenu.java
@@ -25,7 +25,6 @@ import com.skyisland.questmanager.ui.ChatMenu;
 
 /**
  * A basic text-only menu.
- * @author Skyler
  *
  */
 public class SimpleChatMenu extends ChatMenu {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/TreeChatMenu.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/TreeChatMenu.java
@@ -34,7 +34,6 @@ import com.skyisland.questmanager.ui.menu.message.TreeMessage.Option;
 
 /**
  * Menu with multiple options that can lead to other menus.
- * @author Skyler
  *
  */
 public class TreeChatMenu extends ChatMenu implements RespondableMenu {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/BootFromPartyAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/BootFromPartyAction.java
@@ -25,7 +25,6 @@ import com.skyisland.questmanager.player.QuestPlayer;
 
 /**
  * Boots a player from a party
- * @author Skyler
  *
  */
 public class BootFromPartyAction implements MenuAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/ChargeAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/ChargeAction.java
@@ -37,7 +37,6 @@ import org.bukkit.event.player.PlayerMoveEvent;
 
 /**
  * An action that must charge for a while, and then happens
- * @author Skyler
  *
  */
 public class ChargeAction implements Listener, Alarmable<Integer> {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/CraftServiceAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/CraftServiceAction.java
@@ -33,7 +33,6 @@ import io.puharesource.mc.titlemanager.api.TitleObject;
 
 /**
  * Takes a list of requirements and a fee and produces results
- * @author Skyler
  *
  */
 public class CraftServiceAction implements MenuAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/CreateImbuementAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/CreateImbuementAction.java
@@ -37,7 +37,6 @@ import org.bukkit.inventory.ItemStack;
 /**
  * Takes items (presumably from the imbuement table menu) and makes them into an imbuement, and registers
  * such to the player
- * @author Skyler
  *
  */
 public class CreateImbuementAction implements MenuAction, FillableInventoryAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/ForgeAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/ForgeAction.java
@@ -37,7 +37,6 @@ import io.puharesource.mc.titlemanager.api.TitleObject;
 
 /**
  * Repairs a player's equipment
- * @author Skyler
  *
  */
 public class ForgeAction implements MenuAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/InnAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/InnAction.java
@@ -36,7 +36,6 @@ import io.puharesource.mc.titlemanager.api.TitleObject;
 
 /**
  * Rests a player, restoring health and hunger
- * @author Skyler
  *
  */
 public class InnAction implements MenuAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/JoinPartyAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/JoinPartyAction.java
@@ -28,7 +28,6 @@ import com.skyisland.questmanager.player.QuestPlayer;
 
 /**
  * Adds a player to another player's party, creating it if it doesn't exist
- * @author Skyler
  *
  */
 public class JoinPartyAction implements MenuAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/LevelupHealthAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/LevelupHealthAction.java
@@ -30,7 +30,6 @@ import io.puharesource.mc.titlemanager.api.TitleObject;
 
 /**
  * Levels up a player, awarding them some amount of health
- * @author Skyler
  *
  */
 public class LevelupHealthAction implements MenuAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/LevelupManaAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/LevelupManaAction.java
@@ -29,7 +29,6 @@ import io.puharesource.mc.titlemanager.api.TitleObject;
 
 /**
  * Levels up a player, awarding them some amount of mana
- * @author Skyler
  *
  */
 public class LevelupManaAction implements MenuAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/OfferServiceAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/OfferServiceAction.java
@@ -35,7 +35,6 @@ import io.puharesource.mc.titlemanager.api.TitleObject;
 
 /**
  * Trades an itemstack for some currency
- * @author Skyler
  *
  */
 public class OfferServiceAction implements MenuAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/OpenInventoryAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/OpenInventoryAction.java
@@ -26,7 +26,6 @@ import com.skyisland.questmanager.player.QuestPlayer;
 /**
  * Opens a simple inventory. Does no syncing or saving of data, or managing
  * of the inventory. Just shows it to a player
- * @author Skyler
  *
  */
 public class OpenInventoryAction implements MenuAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/PurchaseAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/PurchaseAction.java
@@ -27,7 +27,6 @@ import com.skyisland.questmanager.player.QuestPlayer;
  * The action of purchasing an item or service from an NPC.
  * This event specifically details purchases done from within an InventoryMenu, where it has
  * an ItemStack to give to the player
- * @author Skyler
  *
  */
 public class PurchaseAction implements MenuAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/PurchaseSpellAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/PurchaseSpellAction.java
@@ -25,7 +25,6 @@ import org.bukkit.entity.Player;
  * The action of purchasing an item or service from an NPC.
  * This event specifically details purchases done from within an InventoryMenu, where it has
  * an ItemStack to give to the player
- * @author Skyler
  *
  */
 public class PurchaseSpellAction implements MenuAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/ShowChatMenuAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/ShowChatMenuAction.java
@@ -24,7 +24,6 @@ import com.skyisland.questmanager.ui.ChatMenu;
 
 /**
  * Actions that causes a chat menu to be shown to a player
- * @author Skyler
  *
  */
 public class ShowChatMenuAction implements MenuAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/TeleportAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/TeleportAction.java
@@ -30,7 +30,6 @@ import org.bukkit.potion.PotionEffectType;
 
 /**
  * Ferries a player
- * @author Skyler
  *
  */
 public class TeleportAction implements MenuAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/action/TogglePlayerOptionAction.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/action/TogglePlayerOptionAction.java
@@ -26,7 +26,6 @@ import com.skyisland.questmanager.player.PlayerOptions;
 
 /**
  * Toggles a specific player option
- * @author Skyler
  *
  */
 public class TogglePlayerOptionAction implements MenuAction {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/inventory/BasicInventory.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/inventory/BasicInventory.java
@@ -38,7 +38,6 @@ import com.google.common.collect.Lists;
 
 /**
  * An inventory used with inventory gui's. Contains everything the rendered inventory needs
- * @author Skyler
  *
  */
 public class BasicInventory extends GuiInventory {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/inventory/BasicInventoryItem.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/inventory/BasicInventoryItem.java
@@ -34,7 +34,6 @@ import net.md_5.bungee.api.ChatColor;
  * An item used in an inventory menu.
  * This is composed of an actual item stack, a display item type, and the cost and fame requirement
  * of the item.
- * @author Skyler
  *
  */
 public class BasicInventoryItem extends InventoryItem {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/inventory/CloseableGui.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/inventory/CloseableGui.java
@@ -20,7 +20,6 @@ package com.skyisland.questmanager.ui.menu.inventory;
 
 /**
  * This gui can be closed, and has some sort of prepared response. This typically involves cleaning up or delivering results
- * @author Skyler
  *
  */
 public interface CloseableGui {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/inventory/ContributionInventory.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/inventory/ContributionInventory.java
@@ -36,7 +36,6 @@ import com.skyisland.questmanager.ui.menu.action.MenuAction;
 /**
  * Gui used to 'receive items' from a player's inventory. Allows specification of a filter
  * for runtime awesomeness
- * @author Skyler
  *
  */
 public class ContributionInventory extends GuiInventory {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/inventory/GuiInventory.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/inventory/GuiInventory.java
@@ -27,7 +27,6 @@ import com.skyisland.questmanager.player.QuestPlayer;
  * An inventory used with inventory gui's. Contains everything the rendered inventory needs.
  * Implementations should provide a way to load and save their information, as well as how to format the inventory for
  * display.
- * @author Skyler
  *
  */
 public abstract class GuiInventory implements ConfigurationSerializable {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/inventory/InventoryItem.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/inventory/InventoryItem.java
@@ -27,7 +27,6 @@ import com.skyisland.questmanager.ui.menu.action.MenuAction;
  * An item used in an inventory menu.
  * This is composed of an actual item stack, a display item type, and the cost and fame requirement
  * of the item.
- * @author Skyler
  *
  */
 public abstract class InventoryItem {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/inventory/ServiceCraftItem.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/inventory/ServiceCraftItem.java
@@ -35,7 +35,6 @@ import com.skyisland.questmanager.ui.menu.action.MenuAction;
 
 /**
  * Represents a craft the service NPC can perform.
- * @author Skyler
  *
  */
 public class ServiceCraftItem extends ServiceItem {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/inventory/ServiceInventory.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/inventory/ServiceInventory.java
@@ -37,7 +37,6 @@ import com.skyisland.questmanager.npc.utils.ServiceOffer;
 /**
  * Inventory that has service deals.
  * The inventory can hold only service items, and not regular purchases.
- * @author Skyler
  *
  */
 public class ServiceInventory extends GuiInventory {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/inventory/ServiceOfferItem.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/inventory/ServiceOfferItem.java
@@ -35,7 +35,6 @@ import com.skyisland.questmanager.ui.menu.message.PlainMessage;
 
 /**
  * Represents a craft the service NPC can perform.
- * @author Skyler
  *
  */
 public class ServiceOfferItem extends ServiceItem {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/inventory/ShopInventory.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/inventory/ShopInventory.java
@@ -33,7 +33,6 @@ import org.bukkit.inventory.ItemStack;
 
 /**
  * An inventory used with inventory gui's. Contains everything the rendered inventory needs
- * @author Skyler
  *
  */
 public class ShopInventory extends GuiInventory {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/inventory/ShopItem.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/inventory/ShopItem.java
@@ -32,7 +32,6 @@ import com.skyisland.questmanager.ui.menu.action.MenuAction;
  * An item used in an inventory menu.
  * This is composed of an actual item stack, a display item type, and the cost and fame requirement
  * of the item.
- * @author Skyler
  *
  */
 public class ShopItem extends InventoryItem {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/inventory/ShopSpell.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/inventory/ShopSpell.java
@@ -28,7 +28,6 @@ import com.skyisland.questmanager.ui.menu.action.PurchaseSpellAction;
  * An item used in an inventory menu.
  * This is composed of an actual item stack, a display item type, and the cost and fame requirement
  * of the item.
- * @author Skyler
  *
  */
 public class ShopSpell extends ShopItem {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/message/BioptionMessage.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/message/BioptionMessage.java
@@ -29,7 +29,6 @@ import com.skyisland.questmanager.ui.ChatGuiHandler;
 
 /**
  * Wrapping/formatting class for a message with two options.
- * @author Skyler
  *
  */
 public class BioptionMessage extends Message {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/message/Message.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/message/Message.java
@@ -23,7 +23,6 @@ import org.bukkit.configuration.serialization.ConfigurationSerializable;
 
 /**
  * Holds a messaged used with a menu.
- * @author Skyler
  *
  */
 public abstract class Message implements ConfigurationSerializable {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/message/PlainMessage.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/message/PlainMessage.java
@@ -26,7 +26,6 @@ import org.bukkit.configuration.serialization.ConfigurationSerialization;
 
 /**
  * Wraps arounds a simple, single -use- message.
- * @author Skyler
  *
  */
 public class PlainMessage extends Message {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/message/SimpleMessage.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/message/SimpleMessage.java
@@ -27,7 +27,6 @@ import org.bukkit.configuration.serialization.ConfigurationSerialization;
 
 /**
  * Wraps arounds a simple, single -use- message.
- * @author Skyler
  *
  */
 public class SimpleMessage extends Message {

--- a/src/main/java/com/skyisland/questmanager/ui/menu/message/TreeMessage.java
+++ b/src/main/java/com/skyisland/questmanager/ui/menu/message/TreeMessage.java
@@ -33,7 +33,6 @@ import org.bukkit.configuration.serialization.ConfigurationSerialization;
  * Message that has multiple options and multiple messages that happen because of that option.
  * Messages spawn new menus to display them. This means this tree can have a cascading tree flow
  * and branch into other trees.
- * @author Skyler
  *
  */
 public class TreeMessage extends Message {


### PR DESCRIPTION
This PR updates the Lootable interface to only have one method: loot(), which returns a single Loot object.

This leaves the method of choosing the loot up the the implementer of the Lootable interface.
The static method for choosing random loot has been moved to the Loot class. Just didn't feel quite right as a static method.
